### PR TITLE
New command 'recent' in im to see recent abes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,45 @@
 # yotaco
 Blatant heytaco rip off
 
+## required AWS resources
+
+- A lambda to receive web hooks (POST requests) from Slack. Typically called 'yotaco-webhook'
+
+- A lambda to process messages sent from the web hook processer via SNS. Typically called 'yotaco-msg_processor'
+    - Set timeout to AT LEAST 10 seconds
+
+- An SNS queue for messages from the webhook to be processed by the message processor 
+
+- Two dynamo db tables 
+
+    - taco_transactions
+        - primary partition key: tid String
+        - Secondary index 'from-timestamp-index'
+            - primary partition key: from String
+            - primary sort key: timestamp Number
+        - Secondary index 'cid-index'
+            - primary partition key: cid String
+
+    - taco_counts
+        - primary partition key: cid String
+
+## Slack configuration
+
+- Create a new app
+
+- Add a bot user to the app
+
+- Required OAuth scopes:
+
+  - channels:history
+  - bot
+  - users:read
+  - channels:read
+
+- Add an event subscription to 'message.channels'
+
+- Add a bot event subscription to 'message.im'
+
 ## webhook
 handles slack event webhook
 
@@ -16,9 +55,9 @@ handles slack event webhook
 handles slack message processing
 
 ### ENV vars
-| Key               | Description                                   | Default  |
-| ----------------- | --------------------------------------------- | -------- |
-| DEBUG             | enable verbose logging                        | false    |
-| EMOJI             | text of the slack emoji to use as taco        | taco     |
-| SLACK_BOT_TOKEN   | slack bot token for api                       |          |
-| TZ_OFFSET         | timezone offset, positive or negative integet | 0        |
+| Key               | Description                                                              | Default  |
+| ----------------- | ------------------------------------------------------------------------ | -------- |
+| DEBUG             | enable verbose logging                                                   | false    |
+| EMOJI             | text of the slack emoji to use as taco                                   | taco     |
+| SLACK_BOT_TOKEN   | slack bot token for api                                                  |          |
+| TZ_OFFSET         | timezone offset in hours, positive or negative integer (e.g. -8 for PST) | 0        |

--- a/msg_processor/lambda_function.py
+++ b/msg_processor/lambda_function.py
@@ -11,7 +11,6 @@ import os
 import re
 import requests
 
-print('Loading function')
 
 debug = os.getenv('DEBUG', 'false')
 taco_name = os.getenv('EMOJI', 'taco')
@@ -19,20 +18,27 @@ timezone = os.getenv('TZ_OFFSET', 0)
 bot_token = os.environ['SLACK_BOT_TOKEN']
 bot_user  = os.environ['SLACK_BOT_USER']
 
+print('Loading function', debug, taco_name, timezone, bot_user)
 
-def dynamo_add_taco(ts, index, team, channel, fromu, tou):
+def dynamo_add_taco(ts, index, team, channel, channel_display_name, fromu, from_display_name, tou, to_display_name, message):
     dynamodb = boto3.resource('dynamodb', region_name='us-west-2')
 
     # Add Taco Transaction
     transaction_table = dynamodb.Table('taco_transactions')
+    ts_str = "%017.6f" % float(ts)
     transaction_table.put_item(
         Item={
-            'tid': str(ts) + "-" + team + "-" + channel + "-" + str(index),
+            'tid': ts_str + "-" + team + "-" + channel + "-" + str(index),
             'timestamp': decimal.Decimal(ts),
+            'cid': get_cid_today(team),
             'channel': channel,
+            'channel_display_name': channel_display_name,
             'team': team,
             'from': fromu,
-            'to': tou
+            'to': tou,
+            'from_display_name': from_display_name,
+            'to_display_name': to_display_name,
+            'message': message
         }
     )
 
@@ -84,6 +90,24 @@ def dynamo_add_taco(ts, index, team, channel, fromu, tou):
 
     return
 
+def dynamo_get_recents(team, days=0):
+    dynamodb = boto3.resource('dynamodb', region_name='us-west-2')
+    table = dynamodb.Table('taco_transactions')
+
+    by_person = {}
+
+    for day_back in range(days, -1, -1):
+        cid = get_cid_back(team, day_back)
+        date = cid[0:10]
+        response = table.query(
+            IndexName='cid-index',
+            KeyConditionExpression=Key('cid').eq(cid)
+        )
+        for record in response.get("Items", []):
+            person_data = by_person.setdefault(record['to_display_name'], {}).setdefault(date, [])
+            person_data.append(record)
+
+    return by_person
 
 def dynamo_get_leaderboard(cid):
     dynamodb = boto3.resource('dynamodb', region_name='us-west-2')
@@ -160,10 +184,13 @@ def get_cid_this_year(team):
     return midnight.strftime('%Y') + "-" + team
 
 
+def get_cid_back(team, back):
+    midnight = get_local_midnight() - datetime.timedelta(days=back)
+    return midnight.strftime('%Y-%m-%d') + "-" + team
+
 def get_cid_today(team):
     midnight = get_local_midnight()
     return midnight.strftime('%Y-%m-%d') + "-" + team
-
 
 def get_epoch(ts):
     return int(((ts - datetime.datetime(1970, 1, 1)) - datetime.timedelta(hours=int(timezone))).total_seconds())
@@ -182,6 +209,26 @@ def get_team_name():
 
     return team_info['team']['name']
 
+def get_user_display_name(user_id):
+    params = {"token": bot_token, "user": user_id}
+    r = requests.get('https://slack.com/api/users.info', params=params)
+    user_info = r.json()
+
+    return user_info['user']['name']
+
+def get_channel_display_name(channel_id):
+    params = {"token": bot_token, "channel": channel_id}
+    r = requests.get('https://slack.com/api/conversations.info', params=params)
+    channel_info = r.json()
+
+    return channel_info['channel']['name']
+
+def get_channel_members(channel_id):
+    params = {"token": bot_token, "channel": channel_id}
+    r = requests.get('https://slack.com/api/conversations.members', params=params)
+    channel_info = r.json()
+
+    return set(channel_info['members'])
 
 def get_time_to_next_midnight():
     st = datetime.datetime.now() + datetime.timedelta(hours=int(timezone))
@@ -199,10 +246,15 @@ def get_user_name(user_id):
 
 def process_tacos(tc, tu, tr, body):
     index = 1
+    from_user_display_name = get_user_display_name(body['event']['user'])
+    channel_display_name = get_channel_display_name(body['event']['channel'])
     for user in tu:
         for x in range(tc):
-            dynamo_add_taco(body['event']['event_ts'], index, body['team_id'], body['event']['channel'],
-                            body['event']['user'], user)
+            user_display_name = get_user_display_name(user)
+            dynamo_add_taco(body['event']['event_ts'], index, body['team_id'], 
+                            body['event']['channel'], channel_display_name,
+                            body['event']['user'], from_user_display_name, user, user_display_name,
+                            body['event']['text'])
             index = index + 1
 
         send_message_you_got_taco(user, tc, body['event']['user'], body['event']['channel'], body['event']['text'])
@@ -220,6 +272,33 @@ def respond(err, res=None):
         },
     }
 
+
+def send_message_recent(channel, team, users_in_channel=None):
+    days = 7
+    recents_by_user = dynamo_get_recents(team, days)
+
+    channel_members = None
+    if users_in_channel is not None:
+        channel_members = get_channel_members(users_in_channel)
+
+    message = "Recent %d days\n\n" % days
+    for user, by_day in recents_by_user.iteritems():
+        for day, items in by_day.iteritems():
+            if channel_members is not None and items[0]["to"] not in channel_members:
+                continue
+
+            message += "@%s received %d:\n" % (user, len(items))
+
+            for item in items:
+                for_string = item["message"]
+                if "to_display_name" in item:
+                    for_string = for_string.replace('<@%s>' % item.get("to"), '@' + item["to_display_name"])
+                if "from_display_name" in item:
+                    for_string = for_string.replace('<@%s>' % item.get("from"), '@' + item["from_display_name"])
+                message += "%s in #%s from @%s for '%s'\n" % (day, item["channel_display_name"], item["from_display_name"], for_string)
+
+    attachment = "[{\"text\": \"" + message + "\"}]"
+    send_slack_message(None, channel, attachment)
 
 def send_message_leaderboard(channel, team, time_range):
     leaderboard = []
@@ -362,14 +441,21 @@ def slack_message(body):
         if body['event']['text'] == p.plural(taco_name):
             my_tacos_avail = dynamo_get_tacos_avail(body['event']['user'])
             send_message_tacos_available(body['event']['user'], my_tacos_avail)
-        elif body['event']['text'] == 'leaderboard' or body['event']['text'] == 'leaderboard weekly':
+        elif body['event']['text'] in ('leaderboard', 'leaderboard weekly'):
             send_message_leaderboard(body['event']['user'], body['team_id'], 'weekly')
-        elif body['event']['text'] == 'leaderboard daily' or body['event']['text'] == 'leaderboard today':
+        elif body['event']['text'] in ('leaderboard daily', 'leaderboard today'):
             send_message_leaderboard(body['event']['user'], body['team_id'], 'daily')
         elif body['event']['text'] == 'leaderboard monthly':
             send_message_leaderboard(body['event']['user'], body['team_id'], 'monthly')
         elif body['event']['text'] == 'leaderboard yearly':
             send_message_leaderboard(body['event']['user'], body['team_id'], 'yearly')
+        elif body['event']['text'].startswith('recent'):
+            args = body['event']['text'].split(' ')
+            if len(args) > 1 and args[1].startswith('<#'):
+                channel_filter = re.match('<#([^\|>]*)', args[1]).group(1)
+            else:
+                channel_filter = None
+            send_message_recent(body['event']['user'], body['team_id'], channel_filter)
 
     return
 


### PR DESCRIPTION
Hey Matt, 

This change adds a new im only command to the bot, 'recent' that will show abes given over the past 7 days. You can optionally specify a channel, e.g. 'recent #product' to only see abes given to members of that specific channel. 

To work this code would require a new secondary index added to the 'taco_transactions' dynamo db table with just 'cid' as the partition key. 

Happy to take feedback on fixes / changes you'd prefer. 

Thanks,
Shaun